### PR TITLE
Fixed classes and escaping in label atributes

### DIFF
--- a/src/LatteBundle/Resources/views/Bootstrap3/form_label.html.latte
+++ b/src/LatteBundle/Resources/views/Bootstrap3/form_label.html.latte
@@ -3,5 +3,10 @@
         {var label => $name|humanize}
     {/if}
     <label
-        n:class="$required ? required, isset($label_attr['class']) ? $label_attr['class']" n:attr="for => !$compound ? $id" {foreach $label_attr as $attrname => $attrvalue}{$attrname}="{$attrvalue}"{/foreach}>{$label}</label>
+        n:class="$required ? required, isset($label_attr['class']) ? $label_attr['class']"
+        n:attr="for => !$compound ? $id"
+        {foreach $label_attr as $attrname => $attrvalue}
+            {if $attrname != 'class'}{$attrname|noescape}="{$attrvalue|noescape}"{/if}
+        {/foreach}
+    >{$label}</label>
 {/if}


### PR DESCRIPTION
Do labelu se vypisují třídy duplicitně + se při vypisování v tom foreach escapují, takže výsledné html vypadá např. `<a href="" "class"=""button"">`
